### PR TITLE
Switch to static tab

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1,4 +1,18 @@
-chrome.tabs.onActivated.addListener(moveToFirstPosition);
+// chrome.tabs.onActivated.addListener(moveToFirstPosition);
+
+chrome.action.onClicked.addListener((tab) => {
+  chrome.scripting.executeScript({
+    target: {tabId: tab.id},
+    func: contentScriptFunc,
+    args: ['action'],
+  });
+});
+
+function contentScriptFunc(name) {
+  alert(`"${name}" executed`);
+}
+
+
 
 async function moveToFirstPosition(activeInfo) {
   try {

--- a/src/background.js
+++ b/src/background.js
@@ -1,4 +1,5 @@
-// chrome.tabs.onActivated.addListener(moveToFirstPosition);
+var currTabIndex = 0;
+var lastTabIndex = -1;
 
 // Listen for keyboard shortcut
 chrome.commands.onCommand.addListener(function(command) {
@@ -11,12 +12,26 @@ chrome.commands.onCommand.addListener(function(command) {
       //   is received from the query and then the function later switches between tabs
       chrome.tabs.query({currentWindow: true}, function(tabs) {
           console.log(tabs);
-          console.log(tabs[0]);
+          // we have assertions here to check if the last tab index is invalid
+          console.assert((lastTabIndex >= 0), "The last tab index is less than 0");
+          console.assert((lastTabIndex < tabs.length), "The last tab index is more than the number of tabs");
+          console.log(tabs[lastTabIndex]);
+          console.log(`lastTabIndex listed: ${lastTabIndex}`)
           // the update method grabs the tab it receives in the first parameter and
           //   makes its 'active' and 'highlight' features true, which acts to switch to it
           // 'active' lets the tab be computationally active
           // 'highlighted' does the actual switching to the tab
-          chrome.tabs.update(tabs[0].id, {active: true, highlighted: true});
+          chrome.tabs.update(tabs[lastTabIndex].id, {active: true, highlighted: true});
       });
   }
+});
+
+// Listen for every new tab
+chrome.tabs.onActivated.addListener(function(activeInfo) {
+  // console.log(activeInfo);
+  lastTabIndex = currTabIndex;
+  chrome.tabs.get(activeInfo.tabId, function (tab) {
+    currTabIndex = tab.index;
+  });
+  console.log(`lastTabIndex: ${lastTabIndex}, currTabIndex: ${currTabIndex}`);
 });

--- a/src/background.js
+++ b/src/background.js
@@ -1,0 +1,21 @@
+chrome.tabs.onActivated.addListener(moveToFirstPosition);
+
+async function moveToFirstPosition(activeInfo) {
+  try {
+    await chrome.tabs.move(activeInfo.tabId, {index: 0});
+    console.log("Success.");
+  } catch (error) {
+    if (error == "Error: Tabs cannot be edited right now (user may be dragging a tab).") {
+      setTimeout(() => moveToFirstPosition(activeInfo), 50);
+    } else {
+      console.error(error);
+    }
+  }
+}
+
+async function getCurrentTab() {
+  let queryOptions = { active: true, lastFocusedWindow: true };
+  // `tab` will either be a `tabs.Tab` instance or `undefined`.
+  let [tab] = await chrome.tabs.query(queryOptions);
+  return tab;
+}

--- a/src/background.js
+++ b/src/background.js
@@ -1,35 +1,22 @@
 // chrome.tabs.onActivated.addListener(moveToFirstPosition);
 
-chrome.action.onClicked.addListener((tab) => {
-  chrome.scripting.executeScript({
-    target: {tabId: tab.id},
-    func: contentScriptFunc,
-    args: ['action'],
-  });
-});
-
-function contentScriptFunc(name) {
-  alert(`"${name}" executed`);
-}
-
-
-
-async function moveToFirstPosition(activeInfo) {
-  try {
-    await chrome.tabs.move(activeInfo.tabId, {index: 0});
-    console.log("Success.");
-  } catch (error) {
-    if (error == "Error: Tabs cannot be edited right now (user may be dragging a tab).") {
-      setTimeout(() => moveToFirstPosition(activeInfo), 50);
-    } else {
-      console.error(error);
-    }
+// Listen for keyboard shortcut
+chrome.commands.onCommand.addListener(function(command) {
+  // the 'switch-tab' command is defined in the manifest
+  if (command === "switch-tab") {
+      console.log("command triggered");
+      // the 'query' method essentially queries chrome.tabs for an entry
+      // the parameter here is saying 'give me all the tabs within the current window'
+      // the second argument is a function we provide, that has an argument (tabs) which
+      //   is received from the query and then the function later switches between tabs
+      chrome.tabs.query({currentWindow: true}, function(tabs) {
+          console.log(tabs);
+          console.log(tabs[0]);
+          // the update method grabs the tab it receives in the first parameter and
+          //   makes its 'active' and 'highlight' features true, which acts to switch to it
+          // 'active' lets the tab be computationally active
+          // 'highlighted' does the actual switching to the tab
+          chrome.tabs.update(tabs[0].id, {active: true, highlighted: true});
+      });
   }
-}
-
-async function getCurrentTab() {
-  let queryOptions = { active: true, lastFocusedWindow: true };
-  // `tab` will either be a `tabs.Tab` instance or `undefined`.
-  let [tab] = await chrome.tabs.query(queryOptions);
-  return tab;
-}
+});

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,10 +2,21 @@
   "manifest_version": 3,
   "name": "SmarterTabSwitching",
   "version": "0.1",
-  "icons": {
-    "16": "images/icon-16.png",
-    "32": "images/icon-32.png",
-    "48": "images/icon-48.png",
-    "128": "images/icon-128.png"
+  // "icons": {
+  //   "16": "images/icon-16.png",
+  //   "32": "images/icon-32.png",
+  //   "48": "images/icon-48.png",
+  //   "128": "images/icon-128.png"
+  // }  
+  "host_permissions": [
+    "https://developer.chrome.com/*"
+  ],
+  "action": {
+    "default_title": "Click to show an alert",
+    "default_popup": "popup.html"
+  },
+  "permissions": ["activeTab", "scripting", "tabs"],
+  "background": {
+    "service_worker": "background.js"
   }
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,12 +2,6 @@
   "manifest_version": 3,
   "name": "SmarterTabSwitching",
   "version": "0.1",
-  // "icons": {
-  //   "16": "images/icon-16.png",
-  //   "32": "images/icon-32.png",
-  //   "48": "images/icon-48.png",
-  //   "128": "images/icon-128.png"
-  // }  
   "host_permissions": [
     "https://developer.chrome.com/*"
   ],
@@ -18,5 +12,11 @@
   "permissions": ["activeTab", "scripting", "tabs"],
   "background": {
     "service_worker": "background.js"
+  },
+  "commands": {
+    "_execute_action": {
+      "suggested_key": "Ctrl+Q",
+      "description": "Switch tabs"
+    }
   }
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -6,6 +6,10 @@
   "background": {
     "service_worker": "background.js"
   },
+  "action": {
+    "default_title": "Click to show an alert",
+    "default_popup": "popup.html"
+  },
   "commands": {
     "switch-tab": {
       "suggested_key": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,21 +2,17 @@
   "manifest_version": 3,
   "name": "SmarterTabSwitching",
   "version": "0.1",
-  "host_permissions": [
-    "https://developer.chrome.com/*"
-  ],
-  "action": {
-    "default_title": "Click to show an alert",
-    "default_popup": "popup.html"
-  },
-  "permissions": ["activeTab", "scripting", "tabs"],
+  "permissions": ["tabs"],
   "background": {
     "service_worker": "background.js"
   },
   "commands": {
-    "_execute_action": {
-      "suggested_key": "Ctrl+Q",
-      "description": "Switch tabs"
+    "switch-tab": {
+      "suggested_key": {
+        "default": "Ctrl+Q"
+      },
+      "description": "Move to the first tab",
+      "global": true
     }
   }
 }

--- a/src/popup.html
+++ b/src/popup.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+<!-- HTML Codes by Quackit.com -->
+<title>
+SmarterTabSwitching</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+body {background-color:#ffffff;background-repeat:no-repeat;background-position:top left;background-attachment:fixed;}
+h1{font-family:Arial, sans-serif;color:#000000;background-color:#ffffff;}
+p {font-family:Georgia, serif;font-size:14px;font-style:normal;font-weight:normal;color:#000000;background-color:#ffffff;}
+</style>
+</head>
+<body>
+<h1>SmarterTabSwitching</h1>
+</body>
+</html>


### PR DESCRIPTION
The ability for a hotkey (CTRL+Q) to switch to the last tab, meant to be a prototype that has the core functionality without a MRU cache implemented

Fixed Issues:
- Having our own functionality to change shortcut keys is not needed, there is already a page to allow for that: chrome://extensions/shortcuts. However, we could still add in our own page to do that - within the popup perhaps? [issue](https://github.com/paulstn/SmarterTabSwitching/issues/12)

TODO in another PR:
- Fix all known issues below
- Convert 'changing by tab index' logic over to 'switching by tab id'

Known Issues: 
- [TAB] is a protected key by Chrome, we can later decide if we want the default to be some other key or try to implement ways to still override CTRL+TAB from Chrome. [issue](https://github.com/paulstn/SmarterTabSwitching/issues/25)
- Switching to tabs when the order of tabs change and/or number of tabs change needs to be fixed. [issue](https://github.com/paulstn/SmarterTabSwitching/issues/23)
  - One solution: Use a comprehensive cache that is a stack of tab ids - ids are unique (handles moving tabs) and the stack will present whatever tab is on top, if tabs need to be removed from the stack (handles deleted tabs). Will need logic to figure out where a tab's index is, or maybe even later cache indices for better performance. 
- Initialization is wrong. Instead of setting lastTabIndex to 0, it should be set to an actual tab's index. [issue](https://github.com/paulstn/SmarterTabSwitching/issues/24)
- Tab Switching does not work well with multiple windows, seems to break easily. [issue](https://github.com/paulstn/SmarterTabSwitching/issues/22)