### PR TITLE
Added basic selective command listening

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -54,19 +54,15 @@ chrome.commands.onCommand.addListener(async function(command) {
   // the 'switch-tab' command is defined in the manifest
   if (command === "switch-tab") {
       console.log("Chrome.commands: Trying switch");
-      // TODO: try changing to a promise
-      let url = "unset";
-      chrome.tabs.query({active: true, currentWindow: true}, async (tabs) => {
-        url = tabs[0].url;
-        console.log(url);
+      let promisedTabs = chrome.tabs.query({active: true, currentWindow: true});
+      promisedTabs.then(async (tabs) => {
+        let url = tabs[0].url;
         const toMatch = "chrome://";
         if (url.slice(0,9) === toMatch) {
           console.log("       Restricted Switch Done");
           await switch_tab(1);
-        }
+        }      
       });
-      // let promise = chrome.tabs.query({active: true, lastFocusedWindow: true});
-      // url = promise.then((tabs) => {url = tabs[0].url;});
   }
 });
 

--- a/src/background.js
+++ b/src/background.js
@@ -56,14 +56,15 @@ chrome.commands.onCommand.addListener(async function(command) {
       console.log("Chrome.commands: Trying switch");
       let tabs = await chrome.tabs.query({active: true, currentWindow: true});
       let url = tabs[0].url;
-      const toMatch = "chrome://";
-      if (url.slice(0,9) === toMatch) {
-        // immediately switch if we're on a restricted site
-        console.log("       Restricted Switch Done");
-        await switch_tab(1);
-      } else {
+      const https = "https://";
+      const http = "http://";
+      if (url.slice(0,8) === https || url.slice(0,8) === http) {
         // send a message to content scripts, q was pressed w/ ctrl
         await chrome.tabs.sendMessage(tabs[0].id, {qPressed: true});
+        // immediately switch if we're on a restricted site
+      } else {
+        console.log("       Restricted Switch Done");
+        await switch_tab(1);
       }
   }
 });

--- a/src/background.js
+++ b/src/background.js
@@ -54,15 +54,13 @@ chrome.commands.onCommand.addListener(async function(command) {
   // the 'switch-tab' command is defined in the manifest
   if (command === "switch-tab") {
       console.log("Chrome.commands: Trying switch");
-      let promisedTabs = chrome.tabs.query({active: true, currentWindow: true});
-      promisedTabs.then(async (tabs) => {
-        let url = tabs[0].url;
-        const toMatch = "chrome://";
-        if (url.slice(0,9) === toMatch) {
-          console.log("       Restricted Switch Done");
-          await switch_tab(1);
-        }      
-      });
+      let tabs = await chrome.tabs.query({active: true, currentWindow: true});
+      let url = tabs[0].url;
+      const toMatch = "chrome://";
+      if (url.slice(0,9) === toMatch) {
+        console.log("       Restricted Switch Done");
+        await switch_tab(1);
+      }
   }
 });
 

--- a/src/background.js
+++ b/src/background.js
@@ -58,8 +58,12 @@ chrome.commands.onCommand.addListener(async function(command) {
       let url = tabs[0].url;
       const toMatch = "chrome://";
       if (url.slice(0,9) === toMatch) {
+        // immediately switch if we're on a restricted site
         console.log("       Restricted Switch Done");
         await switch_tab(1);
+      } else {
+        // send a message to content scripts, q was pressed w/ ctrl
+        await chrome.tabs.sendMessage(tabs[0].id, {qPressed: true});
       }
   }
 });
@@ -91,13 +95,9 @@ chrome.tabs.onActivated.addListener(async function(activeInfo) {
 
 chrome.runtime.onMessage.addListener((message,sender,sendResponse)=>{
   if (DEBUG) { console.log(message); };
-  if (message == "CTRL Q PRESSED") {
-    switch_tab(1);
-    console.log("Content Scripts: Switch tabs once");
-    sendResponse("Content Scripts: Switch tabs once");
-  } else if (typeof message == "number") {
-    switch_tab(message);
-    console.log("Content Scripts: Switched to " + message + " most recently used tab");
-    sendResponse("Content Scripts: Switched to " + message + " most recently used tab");
+  // this should check if the message has the object contentPresses
+  if (message.contentPresses) {
+    switch_tab(message.contentPresses);
+    console.log("Content Scripts: Switched to " + message.contentPresses + " most recently used tab");
   }
 })

--- a/src/command-testing.js
+++ b/src/command-testing.js
@@ -11,11 +11,16 @@ window.addEventListener('keydown', (event) => {
     if (event.key == "Control") {
         ctrlDown = true;
     }
-
-    if (event.key == "q") {
-        qDown = true;
-    }
 });
+
+// helpful message from extension letting us know ctrl and q were pressed together
+chrome.runtime.onMessage.addListener(
+    function(request, sender, sendResponse) {
+      if (request.qPressed) {
+        qDown = true;
+      }
+    }
+  );  
 
 window.addEventListener('keyup', (event) => {    
     if (event.key == "Control") {
@@ -30,24 +35,18 @@ window.addEventListener('keyup', (event) => {
             preview.remove();
 
             // CTRL TAB HELD
-            chrome.runtime.sendMessage(null,
-                                numSwitches % 5, 
-                                (response)=>{
-                console.log("Sent key value: " + response);
-            });         
+            chrome.runtime.sendMessage(null, {contentPresses: numSwitches % 5});         
 
             multipleOccurs = false;
             numSwitches = 0;
         } else if (qDown) {
             // this block is meant to handle a single switching, only switching to the previous
             // most recently used tab
-            console.log("Single Switch");   
+            console.log("Single Switch");
+            
+            qDown = false;
 
-            chrome.runtime.sendMessage(null,
-                                    "CTRL Q PRESSED",
-                                    (response)=>{
-                console.log("Sent key value: " + response)
-            });         
+            chrome.runtime.sendMessage(null, {contentPresses: 1});         
         }
     }
     if (event.key == "q") {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -22,13 +22,13 @@
     }
   ],
   "commands": {
-    // "switch-tab": {
-    //   "suggested_key": {
-    //     "default": "Ctrl+Q"
-    //   },
-    //   "description": "Move to the first tab",
-    //   "global": true
-    // }
+    "switch-tab": {
+      "suggested_key": {
+        "default": "Ctrl+Q"
+      },
+      "description": "Move to the first tab",
+      "global": true
+    }
   },
   "content_scripts": [
     {

--- a/src/popup.html
+++ b/src/popup.html
@@ -13,5 +13,6 @@ p {font-family:Georgia, serif;font-size:14px;font-style:normal;font-weight:norma
 </head>
 <body>
 <h1>SmarterTabSwitching</h1>
+<h2>Go to chrome://extensions/shortcuts if you want to set a shortcut to work on restricted websites, like newtab</h2>
 </body>
 </html>

--- a/test/integration/test-commands.js
+++ b/test/integration/test-commands.js
@@ -76,7 +76,33 @@ test("Extension command to functionality test", async (t) => {
 
     // await t.test("Test content-script multiple Multiple Switching");
 
-    // await t.test("Test Restricted Tab Switching");
+    await t.test("Test Restricted Tab Switching", async (t) => {
+        const page1 = await browser.newPage();
+        await page1.bringToFront();
+        const page2 = await browser.newPage();
+        await page2.bringToFront();
+
+        assert.notStrictEqual(await getActivePage(browser, 3000), page1, "expected us to be on page 2");
+        assert.strictEqual(await getActivePage(browser, 3000), page2, "expected us to be on page 2");
+
+        await page2.keyboard.down("Control");
+
+        await sleep(100);
+
+        await page2.keyboard.down("KeyQ");
+
+        await sleep(100);
+
+        await page2.keyboard.up("KeyQ");
+
+        await sleep(100);
+
+        await page2.keyboard.up('Control');
+
+        await sleep(100);
+
+        assert.strictEqual(await getActivePage(browser, 3000), page1, "we don't end on page 1");
+    });
 
     // await t.test("Test Webpage-Dialogue-Open Switching");
 

--- a/test/integration/test-commands.js
+++ b/test/integration/test-commands.js
@@ -15,7 +15,7 @@ test("Extension command to functionality test", async (t) => {
         await browser.close();
     });
 
-    await t.test("Test content-script Single Switching", async (t) => {
+    await t.test("Test content-script Single Switching", {skip: "non finished"}, async (t) => {
         const page1 = await browser.newPage();
         await page1.bringToFront();
         await page2.goto("chrome://extensions/", {waitUntil: 'domcontentloaded'});
@@ -76,7 +76,7 @@ test("Extension command to functionality test", async (t) => {
 
     // await t.test("Test content-script multiple Multiple Switching");
 
-    await t.test("Test Restricted Tab Switching", async (t) => {
+    await t.test("Test Restricted Tab Switching", {skip: "non finished"}, async (t) => {
         const page1 = await browser.newPage();
         await page1.bringToFront();
         const page2 = await browser.newPage();

--- a/test/integration/test-commands.js
+++ b/test/integration/test-commands.js
@@ -1,0 +1,105 @@
+'use strict'
+
+import puppeteer from "puppeteer";
+import test from "node:test";
+import assert from "node:assert"
+import {initializeExtension, sleep} from "../utils.js";
+
+test("Extension command to functionality test", async (t) => {
+    var browser = await puppeteer.launch(); await browser.close();
+    var service_worker;
+    t.beforeEach(async (t) => {
+        [browser, service_worker] = await initializeExtension();
+    });
+    t.afterEach(async (t) => {
+        await browser.close();
+    });
+
+    await t.test("Test content-script Single Switching", async (t) => {
+        const page1 = await browser.newPage();
+        await page1.bringToFront();
+        await page2.goto("chrome://extensions/", {waitUntil: 'domcontentloaded'});
+        const page2 = await browser.newPage();
+        await page2.bringToFront();
+        await page2.goto("chrome://extensions/", {waitUntil: 'domcontentloaded'});
+
+        assert.notStrictEqual(await getActivePage(browser, 3000), page1, "expected us to be on page 2");
+        assert.strictEqual(await getActivePage(browser, 3000), page2, "expected us to be on page 2");
+
+        await page2.keyboard.down("Control");
+
+        await sleep(100);
+
+        await page2.keyboard.down("KeyQ");
+
+        await sleep(100);
+
+        await page2.keyboard.up('Control');
+
+        await sleep(100);
+
+        await page2.keyboard.up("KeyQ");
+
+        await sleep(100);
+
+        assert.strictEqual(await getActivePage(browser, 3000), page1, "we don't end on page 1");
+    });
+    
+    await t.test("Test content-script single Multiple Switching", async (t) => {
+        const page1 = await browser.newPage();
+        await page1.bringToFront();
+        const page2 = await browser.newPage();
+        await page2.goto("https://example.com", {waitUntil: 'domcontentloaded'});
+        await page2.bringToFront();
+
+        assert.notStrictEqual(await getActivePage(browser, 3000), page1, "expected us to be on page 2");
+        assert.strictEqual(await getActivePage(browser, 3000), page2, "expected us to be on page 2");
+
+        await page2.keyboard.down("Control");
+
+        await sleep(100);
+
+        await page2.keyboard.down("KeyQ");
+
+        await sleep(100);
+
+        await page2.keyboard.up("KeyQ");
+
+        await sleep(100);
+
+        await page2.keyboard.up('Control');
+
+        await sleep(100);
+
+        assert.strictEqual(await getActivePage(browser, 3000), page1, "we don't end on page 1");
+    });
+
+    // await t.test("Test content-script multiple Multiple Switching");
+
+    // await t.test("Test Restricted Tab Switching");
+
+    // await t.test("Test Webpage-Dialogue-Open Switching");
+
+    // /**
+    //  * "slipping" is an issue that can occur between restricted tabs and regular content-script
+    //  * tabs. What occurs is the mixture between a command being listened to and registered on
+    //  * one side and then again being listened to and registered on the other side, so what 
+    //  * ultimately happens looks like a slip or a bounce
+    //  */
+    // await t.test("Test Slip Switching");
+});
+
+async function getActivePage(browser, timeout) {
+    var start = new Date().getTime();
+    while(new Date().getTime() - start < timeout) {
+        var pages = await browser.pages();
+        var arr = [];
+        for (const p of pages) {
+            if(await p.evaluate(() => { return document.visibilityState == 'visible' })) {
+                arr.push(p);
+            }
+        }
+        if(arr.length == 1) return arr[0];
+    }
+    throw "Unable to get active page";
+}


### PR DESCRIPTION
Only applies the default tab switching (that will immediately switch tabs when getting the command) for restricted websites that start with "chrome://". 
Allows content scripts to do their thing, most of the time. Single switching is somehow disabled (should we maybe go this route?, allow for only multi tab switching?). Multi tab switching is intact and working like normal.