### PR TITLE
Added bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_RERPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_RERPORT.yml
@@ -1,0 +1,33 @@
+name: Bug Report
+description: File a bug report
+title: "[Bug]: "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+    - type: textarea
+    id: system_properties
+    attributes:
+      label: How is the extension being used? (Operating System, browser (i.e. Edge, Chrome, etc))
+      description: Did you install via the extension store or via Github?
+      placeholder: OS, Browser, version, etc.
+    validations:
+      required: true
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: What did you expect to happen?
+      description: include any other steps required to reproduce the scenario
+      placeholder: Expected Behavior
+    validations:
+      required: true
+  - type: textarea
+    id: observed_behavior
+    attributes:
+      label: What actually happened?
+      description: include any other items of note, eg screenshots, console logs, etc.
+      placeholder: Actual Behavior
+    validations:
+      required: true


### PR DESCRIPTION
@paulstn you may need to add this in the repo settings? not sure, see [adding issue templates](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository) for more info.